### PR TITLE
Fix Poetry installation in bootstrap script

### DIFF
--- a/jules_bootstrap.sh
+++ b/jules_bootstrap.sh
@@ -10,18 +10,18 @@ sudo apt -y update
 sudo apt -y full-upgrade
 sudo apt-get install -y nodejs npm
 sudo npm install -g npx
-sudo apt-get install -y python3-pip
+sudo apt-get install -y python3-pip python3-venv
 
 # Instalar Poetry (gerenciador de dependências Python)
 echo "Instalando Poetry..."
-sudo pip3 install poetry
+python3 -m pip install --user poetry
 
 # Instalar dependências do backend com Poetry
 if [ -f "backend/pyproject.toml" ]; then
   echo "Instalando dependências do backend definidas em backend/pyproject.toml..."
   # Executar poetry install de dentro do diretório backend
   # ou usar -C para especificar o diretório do projeto Poetry
-  poetry -C backend install --no-root # --no-root para não instalar o próprio projeto backend como editável, apenas deps
+  ~/.local/bin/poetry -C backend install --no-root # --no-root para não instalar o próprio projeto backend como editável, apenas deps
   # Se o comando acima falhar por permissão, pode ser necessário configurar Poetry para criar venvs no projeto
   # ou garantir que o usuário Jules tenha permissão para ~/.cache/pypoetry
   # Exemplo alternativo se poetry global não for desejado:


### PR DESCRIPTION
- Install python3-venv to ensure virtual environment capabilities.
- Install Poetry to user's local package directory using `python3 -m pip install --user poetry` to avoid conflicts with system packages.
- Use `~/.local/bin/poetry` to execute Poetry commands.