### PR TITLE
Fix: Adjust imports in backend/main.py for Docker environment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,8 +15,8 @@ except ImportError:
         GoogleAPIError = type("GoogleAPIError", (Exception,), {})
 
 
-from backend.orchestrator import Orchestrator, AppStates
-from backend.file_generator import create_project_structure_and_files # Added for bootstrap generation
+from orchestrator import Orchestrator, AppStates
+from file_generator import create_project_structure_and_files # Added for bootstrap generation
 
 # --- Setup Logging ---
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Changed imports from 'backend.module' to 'module' to correctly resolve modules when the backend directory is mapped to /app in Docker and PYTHONPATH is set to /app.

Note: Full local execution and testing were prevented by persistent 'Out of diskspace' errors in the execution environment.